### PR TITLE
Retrieve Tweets from Twitter API and write those tweets back to elasticsearch under 'in_reply_to_status'

### DIFF
--- a/tools/twitter-api/config.json
+++ b/tools/twitter-api/config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "server": "XX"
+  }
+  
+}

--- a/tools/twitter-api/get-tweets.py
+++ b/tools/twitter-api/get-tweets.py
@@ -6,6 +6,9 @@ import tweepy
 creds = json.load(open("creds.json"))
 creds = creds["twitter-creds"]
 
+config = json.load(open("config.json"))
+config = config["config"]
+
 consumer_key        = creds["consumer_key"]
 consumer_key_secret = creds["consumer_key_secret"]
 access_token        = creds["access_token"]
@@ -17,7 +20,7 @@ api = tweepy.API(auth)
 
 def GetElasticSearchHits(): 
   es = Elasticsearch(
-    ['lp01.idea.rpi.edu:443/elasticsearch'],
+    [config["server"]],
     # turn on SSL
     use_ssl=True,
     # no verify SSL certificates
@@ -94,5 +97,6 @@ def GetTweetsFromAPI(hits):
     
 if __name__ == "__main__":
   hits = GetElasticSearchHits()
-  pairs = GetTweetsFromAPI(hits)
-  print(pairs)
+  print(hits[0]['_source']['in_reply_to_status_id'])
+  #pairs = GetTweetsFromAPI(hits)
+  #print(pairs)

--- a/tools/twitter-api/scrolling.py
+++ b/tools/twitter-api/scrolling.py
@@ -1,0 +1,91 @@
+from elasticsearch import Elasticsearch, helpers
+from random import randint
+import json
+config = json.load(open("config.json"))
+ 
+es = Elasticsearch(
+  [config["config"]["server"]],
+  # turn on SSL
+  use_ssl=True,
+  # no verify SSL certificates
+  verify_certs=False,
+  # don't show warnings about ssl certs verification
+  ssl_show_warn=False,
+  timeout=30,
+  max_retries=10,
+  retry_on_timeout=True
+)
+ 
+# create a Python dictionary for the search query:
+search_param = {
+  "_source": True,
+  "query": {
+    "constant_score" : {
+      "filter" : {
+        "exists" : {
+          "field" : "in_reply_to_status_id_str"
+        }
+      }
+    }
+  }
+}
+ 
+es_index = 'coronavirus-data-all'
+ 
+# helper methods to see which 
+def printMappings():
+  # print out searchable indexes in elasticsearch
+  mapping = es.indices.get_mapping(es_index)
+  with open('mapping.json', 'w') as f:
+    f.write(json.dumps(mapping))
+ 
+def validateTweets(tweets):
+  for tweet in tweets:
+    if 'in_reply_to_status_id_str' not in tweet['_source'] or not tweet['_source']['in_reply_to_status_id_str'].isnumeric():
+      print('Non Reply Tweet found')
+      print(tweet)
+      return False
+  return True
+ 
+# method for continuously searching for all tweets
+def search(max_hits=999999999):
+  print('###########################')
+  print('        Begin Search       ')
+  print('###########################')
+  response = []
+ 
+  # perform a search for 2ms and get initial index
+  page = es.search(index=es_index,
+                       scroll='2m',
+                       size=1000,
+                       body=search_param)
+  scroll_id = page['_scroll_id']
+  scroll_size = page['hits']['total']['value']
+  response.extend(page['hits']['hits'])
+  print('%d Tweets Gathered' % (len(response)))
+ 
+  # Start scrolling until we have all documents that match our query
+  while (scroll_size > 0):
+    if (len(response) >= max_hits):
+      break
+    page = es.scroll(scroll_id=scroll_id, scroll='2m')
+    # Update the scroll ID
+    scroll_id = page['_scroll_id']
+    # Get the number of results that we returned in the last scroll
+    validateTweets(page['hits']['hits'])
+    scroll_size = len(page['hits']['hits'])
+    response.extend(page['hits']['hits'])
+    print('%d Tweets Gathered' % (len(response)))
+  return response
+ 
+if __name__ == '__main__':
+  response = search(max_hits=1000)
+  print(len(response))
+ 
+# sentiment as a cluster
+# chop up dataset by sentiment, negative, positive, neutral
+# train a model on it
+# what kind of accuracy we can get?
+# custom attribute, to fill in quoted status
+# output file as json line structure into elasticsearch, quoted status node, take whole json and output it
+# create a new index for each usecase that we have

--- a/tools/twitter-api/twitter_api_handler.py
+++ b/tools/twitter-api/twitter_api_handler.py
@@ -1,0 +1,86 @@
+from scrolling import es, es_index, search
+from elasticsearch import Elasticsearch
+from error_handling import *
+from elasticsearch.helpers import bulk
+from random import randint
+import json
+import tweepy
+
+class TwitterAPIHandler:
+  def __init__(self):
+    creds = json.load(open("creds.json"))
+    self.creds = creds["twitter-creds"]
+    
+    self.consumer_key        = self.creds["consumer_key"]
+    self.consumer_key_secret = self.creds["consumer_key_secret"]
+    self.access_token        = self.creds["access_token"]
+    self.access_token_secret = self.creds["access_token_secret"]
+    self.auth = tweepy.OAuthHandler(self.consumer_key, self.consumer_key_secret)
+    self.auth.set_access_token(self.access_token, self.access_token_secret)
+    self.api = tweepy.API(self.auth, wait_on_rate_limit=True, wait_on_rate_limit_notify=True)
+
+  def GetElasticSearchHitsWithScrolling(self, max_hits):
+    """
+    Uses Thomas Shweh's ElasticSearch scrolling algorithm to get max_hits number of Tweets from
+    ElasticSearch
+    """
+    return search(max_hits=max_hits-1000)
+      
+  def GetFullText(self, apiResponse, index):
+    """
+    For testing to see if the tweet has an extended text
+    """
+    try:
+      return apiResponse[index].full_text
+    except:
+      return -1
+    
+
+  def GetTweetsFromAPI(self, hits):
+    """
+    Gets the original tweet for each response-type hit from Twitter 
+    and writes that original tweet to the exisiting data
+    """
+    output = list()
+    responseTweetIds = [hit['_source']['in_reply_to_status_id'] for hit in hits]
+    numUnavailable = 0
+    for i in range(0, len(responseTweetIds), 100):
+      apiResponse = self.api.statuses_lookup(responseTweetIds[i:i+100], tweet_mode="extended", map=True)
+      responseIndex = 0
+      for j in range(i, i+100):
+        currHit = hits[j]
+        currHit['_source']['in_reply_to_status'] = apiResponse[responseIndex]
+          
+        responseIndex += 1
+        
+        output.append(currHit)
+        
+    return output, numUnavailable
+  
+  def WriteDataToElasticSearch(self, hits):
+    """
+    Write the modified data back to the elasticsearch index
+    """
+    for i in range(0, len(hits), 100):
+      process_batch = hits[i:i+100]
+      del hits[i:i+100]
+      bulk(self.es, process_batch, index=es_index, chunk_size=len(process_batch))
+      
+  
+  def GetOriginalTweetsAndWriteToElasticSearch(self, num_tweets):
+    """
+    Gets num_tweets from ElasticSearch and then queries Twitter for the original tweet that the
+    ElasticSearch Tweet was in response to. Once we get the original tweet, we write it back to 
+    ElasticSearch with the key 'in_response_to_id'
+    """
+    hits = self.GetElasticSearchHitsWithScrolling(max_hits=num_tweets)
+    tweets = self.GetTweetsFromAPI(hits)
+    self.WriteDataToElasticSearch(hits)
+    
+    
+if __name__ == "__main__":
+  retriever = TwitterAPIHandler()
+  """
+  To run full functionality of the script, call:
+  retriever.GetOriginalTweetsAndWriteToElasticSearch(self, num_tweets)
+  """


### PR DESCRIPTION
New functionality for updating an elasticsearch index that contains response tweets. For each tweet in a given index that is a response, we are now able to pull the original tweet (the tweet which the elasticsearch tweet is in response to) from Twitter and include that data in our elasticsearch tweet object under 'in_reply_to_status'. Then, once we have done this for some number of tweets, we can write the updated data back to the index from which we pulled from.

scrolling.py was written by Thomas Shweh
twitter_api_handler.py was written by Brandyn Sigouin