### PR TITLE
Bert Sentiment Scoring Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ twitter_monitor/tmlog.txt
 embedder/embedderlog.txt
 twitter_monitor/jdllog.txt
 sentiment/sentimentlog.txt
+sentiment/semeval*
+sentiment/sentiment.pt
 analysis/snapshots/*.Rdata

--- a/sentiment/bert_eval.py
+++ b/sentiment/bert_eval.py
@@ -1,0 +1,60 @@
+import torch
+import requests
+from transformers import AutoTokenizer
+from torch.nn.functional import softmax
+from typing import List
+
+# global constants
+MODEL_NAME = 'digitalepidemiologylab/covid-twitter-bert-v2'
+tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+mapping = { 0: 'negative', 1: 'neutral', 2: 'positive' }
+
+class BertSentiment():
+	"""
+	Initializes a bert model used for evaluation
+	@param path: local relative path of the bert model
+	@param remote: defaults to empty, if specified will download model from url
+	""" 
+	def __init__(self, path: str, remote: str=""):
+		if len(remote) != 0:
+			self.download(remote)
+		self.tokenizer = tokenizer
+		self.load(path)
+	
+	"""
+	Downloads bert model from remote
+	@param remote: url location of bert model
+	@param dest: destination path where model will be downloaded to
+	"""
+	def download(self, remote: str, dest: str) -> str:
+		try:
+			res = requests.get(remote, allow_redirects=True)
+			with open(dest, "wb") as f:
+				f.write(res.content)
+			return dest
+		except:
+			print("Could not download model")
+			return None
+
+	"""
+	Loads pytorch model in for inference
+	@patam path: local path to the bert model
+	"""
+	def load(self, path:str):
+		self.device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
+		self.model = torch.load(path)
+		self.model.to(self.device)
+		self.model.eval()
+	
+	"""
+	Takes in a tweet and calculates a sentiment prediction confidences
+	"""
+	def score(self, text):
+		encoding = self.tokenizer(text, return_tensors="pt", padding=True)
+		inputs = encoding["input_ids"].to(self.device)
+		logits = self.model(inputs, labels=None)[0]
+		temp = torch.flatten(logits.cpu())
+		preds = softmax(temp, dim=0)
+		sentiment = mapping[torch.argmax(preds).item()]
+		return preds.tolist(), sentiment
+

--- a/sentiment/bert_eval.py
+++ b/sentiment/bert_eval.py
@@ -50,7 +50,7 @@ class BertSentiment():
 	Takes in a tweet and calculates a sentiment prediction confidences
 	"""
 	def score(self, text):
-		encoding = self.tokenizer(text, return_tensors="pt", padding=True)
+		encoding = self.tokenizer(text, return_tensors="pt", padding=True, truncation=True, max_length=35)
 		inputs = encoding["input_ids"].to(self.device)
 		logits = self.model(inputs, labels=None)[0]
 		temp = torch.flatten(logits.cpu())

--- a/sentiment/config.json
+++ b/sentiment/config.json
@@ -2,13 +2,15 @@
     "py/object": "config.Config",
     "elasticsearch_host": "localhost",
     "elasticsearch_verify_certs": false,
-    "elasticsearch_index_name": "coronavirus-data2",
-    "elasticsearch_batch_size": 500,
+    "elasticsearch_index_name": "coronavirus-data-masks",
+    "elasticsearch_batch_size": 1000,
     "elasticsearch_timeout_secs": 30,
     "sleep_idle_secs": 5,
     "sleep_not_idle_secs": 0.01,
-    "log_level": "WARNING",
+    "log_level": "INFO",
     "semeval_dataset" : "semeval",
     "semeval_url" : "https://www.dropbox.com/s/byzr8yoda6bua1b/2017_English_final.zip?dl=1",
-    "thresholds" : [0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45]
+    "thresholds" : [0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45],
+    "model_path" : "bert_sentiment.pt",
+    "model_config" : "bert_config.config"
 }

--- a/sentiment/sentiment.py
+++ b/sentiment/sentiment.py
@@ -35,8 +35,7 @@ vader = SentimentIntensityAnalyzer()
 bert = BertSentiment(config.model_path)
 
 #Initialize elasticsearch settings
-print(config.elasticsearch_verify_certs)
-es = Elasticsearch(hosts=[config.elasticsearch_host], 
+es = Elasticsearch(hosts=[config.elasticsearch_host],
                    verify_certs=config.elasticsearch_verify_certs,
                    timeout=config.elasticsearch_timeout_secs)
 

--- a/sentiment/sentiment_helpers.py
+++ b/sentiment/sentiment_helpers.py
@@ -28,7 +28,7 @@ def get_query():
                    "bool": {
                    "must_not": {
                       "exists": {
-                          "field": "sentiment.bert.class"
+                          "field": "sentiment.bert.primary"
                       }
                     }
                   }

--- a/sentiment/sentiment_helpers.py
+++ b/sentiment/sentiment_helpers.py
@@ -1,47 +1,6 @@
 import re
 
 def get_query():
-#    query = {
-#    "_source": [
-#        "text",
-#        "full_text",
-#        "extended_tweet.full_text",
-#        "quoted_status.text",
-#        "quoted_status.full_text",
-#        "quoted_status.extended_tweet.full_text"
-#    ],
-#    "query": {
-#        "bool": {
-#        "filter": [
-#            {
-#            "bool": {
-#                "must_not": [
-#                   {
-#                   "exists": {
-#                       "field": "sentiment.vader.primary"
-#                     }
-#                   },
-#                   {
-#                   "exists": {
-#                       "field": "sentiment.bert.scores"
-#                     }
-#                   }
-#                ]
-#              }
-#            },
-#            {
-#            "bool": {
-#                "must_not": {
-#                "exists": {
-#                    "field": "retweeted_status.id"
-#                  }
-#                }
-#              }
-#            }
-#          ]
-#        }
-#      }
-#    }
     query = {
     "_source": [
         "text",
@@ -56,11 +15,26 @@ def get_query():
         "filter": [
             {
             "bool": {
-                "must_not": {
-                "exists": {
-                    "field": "sentiment.vader.primary"
+                "should": [{
+                   "bool": {
+                   "must_not": {
+                       "exists": {
+                           "field": "sentiment.vader.primary"
+                       }
+                    }
                   }
-                }
+                 },
+                 {
+                   "bool": {
+                   "must_not": {
+                      "exists": {
+                          "field": "sentiment.bert.class"
+                      }
+                    }
+                  }
+                 }
+                ],
+                "minimum_should_match" : 1 
               }
             },
             {

--- a/sentiment/sentiment_helpers.py
+++ b/sentiment/sentiment_helpers.py
@@ -1,6 +1,47 @@
 import re
 
 def get_query():
+#    query = {
+#    "_source": [
+#        "text",
+#        "full_text",
+#        "extended_tweet.full_text",
+#        "quoted_status.text",
+#        "quoted_status.full_text",
+#        "quoted_status.extended_tweet.full_text"
+#    ],
+#    "query": {
+#        "bool": {
+#        "filter": [
+#            {
+#            "bool": {
+#                "must_not": [
+#                   {
+#                   "exists": {
+#                       "field": "sentiment.vader.primary"
+#                     }
+#                   },
+#                   {
+#                   "exists": {
+#                       "field": "sentiment.bert.scores"
+#                     }
+#                   }
+#                ]
+#              }
+#            },
+#            {
+#            "bool": {
+#                "must_not": {
+#                "exists": {
+#                    "field": "retweeted_status.id"
+#                  }
+#                }
+#              }
+#            }
+#          ]
+#        }
+#      }
+#    }
     query = {
     "_source": [
         "text",


### PR DESCRIPTION
The following script adds sentiment scoring using BERT to elasticsearch.

For each item that is score, the confidences for each class are included alongside it's classification in text.
This PR builds on top of the vader sentiment job and updates the elasticsearch query to score documents that either (do not have vader score OR do not bert score) AND is not a reply tweet.